### PR TITLE
[Validator] Fix missing semicolon for `Choice` constraint documentation

### DIFF
--- a/reference/constraints/Choice.rst
+++ b/reference/constraints/Choice.rst
@@ -250,7 +250,7 @@ you can pass the class name and the method as an array.
         // src/Entity/Author.php
         namespace App\Entity;
 
-        use App\Entity\Genre
+        use App\Entity\Genre;
         use Symfony\Component\Validator\Constraints as Assert;
 
         class Author


### PR DESCRIPTION
There is a small semicolon missing in the documentation, since 5.x branch.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/releases for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `6.x` for features of unreleased versions).

-->
